### PR TITLE
feat(comments): use disqus as first comment section

### DIFF
--- a/docs/.vuepress/components/Author.vue
+++ b/docs/.vuepress/components/Author.vue
@@ -80,6 +80,7 @@ export default {
 <style scoped>
 .author {
   display: flex;
+  margin-bottom: 12px;
 }
 
 .author > .author__description {

--- a/docs/.vuepress/components/Disqus.vue
+++ b/docs/.vuepress/components/Disqus.vue
@@ -1,0 +1,18 @@
+<template>
+  <div id="disqus_thread"></div>
+</template>
+<script>
+export default {
+  mounted() {
+    var disqus_config = function() {
+      this.page.url = window.location.origin;
+      this.page.identifier = window.location.pathname;
+    };
+    const d = window.document,
+      s = d.createElement("script");
+    s.src = "https://https-open-blog-dev.disqus.com/embed.js";
+    s.setAttribute("data-timestamp", +new Date());
+    (d.head || d.body).appendChild(s);
+  }
+};
+</script>

--- a/docs/fr/post/Slasgear/github-classroom-pourquoi-le-tester.md
+++ b/docs/fr/post/Slasgear/github-classroom-pourquoi-le-tester.md
@@ -166,3 +166,5 @@ Pour l'évaluation vous avez deux solutions :
 - Mettre en place des tests unitaires sur le projet de base et connecter un outil de CI en SaaS comme travis-ci.
 
 <Author />
+
+<Disqus />


### PR DESCRIPTION
Blogs often have comment section.

Disqus free mode is great (except tracking part). It should to it for now.

We can imagine using another repository issues to handle comment. Author would just have to define an Issue ID in frontmatter. A dedicated component would load comments on issues and display them in page.