### PR TITLE
feat(canonical): handle canonical urls to links externals source

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 module.exports = {
   title: "Open blog",
   plugins: {
@@ -25,6 +27,7 @@ module.exports = {
       description: "Partage tes articles sur une plateforme libre"
     }
   },
+  clientRootMixin: path.resolve(__dirname, "./mixins/canonical.js"),
   themeConfig: {
     locales: {
       "/": {

--- a/docs/.vuepress/mixins/canonical.js
+++ b/docs/.vuepress/mixins/canonical.js
@@ -1,0 +1,9 @@
+export default {
+  mounted() {
+    const { canonicalUrl } = this.$page.frontmatter;
+    const linkTag = document.createElement("link");
+    linkTag.setAttribute("rel", "canonical");
+    linkTag.setAttribute("href", canonicalUrl);
+    document.head.appendChild(linkTag);
+  }
+};


### PR DESCRIPTION
A blogger can post an article in many blog:
- in a personal blog
- in his/her company blog
- in a platform like dev.to or Medium

For SEO purpose, author have to define where is the "canonical" (the real source) of the article. 
If the article is findable in more than one web page url, it should define the *one*  which is the reference.

With this PR, an author can define the canonical url in frontmatter.

```yml
---
canonicalUrl: https://my-other-url/my-blog-post
---
```